### PR TITLE
Resolved couldn't find sfBlazor in window error

### DIFF
--- a/Client/Program.cs
+++ b/Client/Program.cs
@@ -34,7 +34,7 @@ namespace SyncfusionHelpDeskClient.Client
             builder.Services.AddApiAuthorization();
 
             // Syncfusion support
-            builder.Services.AddSyncfusionBlazor();
+            builder.Services.AddSyncfusionBlazor(true);
 
             await builder.Build().RunAsync();
         }

--- a/Client/wwwroot/index.html
+++ b/Client/wwwroot/index.html
@@ -8,7 +8,8 @@
     <base href="/" />
     <link href="css/bootstrap/bootstrap.min.css" rel="stylesheet" />
     <link href="css/app.css" rel="stylesheet" />
-    <link href="https://cdn.syncfusion.com/blazor/18.1.42/styles/material.css" rel="stylesheet" />
+    <link href="_content/Syncfusion.Blazor/styles/material.css" rel="stylesheet" />
+    <script src="_content/Syncfusion.Blazor/scripts/syncfusion-blazor.min.js" type="text/javascript"></script>
 </head>
 
 <body>


### PR DESCRIPTION
**Description** Script error `Couldn't find sfBlazor in window` throws when refreshing the help desk ticket page.

**Cause** The component tries to invoke the JavaScript method before the interop script loaded on the web page.

**Solution** Prevented the `DisableScriptManager` in `SyncfusionBlazorService` and added the interop files directly in the application. The issue will be resolved on the source side in the upcoming patch release by June 09, 2020.